### PR TITLE
Change `image` to `Dockerfile`

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -10,7 +10,7 @@ inputs:
 
 runs:
     using: 'docker'
-    image: 'docker://cloudbees/plantuml-github-action'
+    image: 'Dockerfile'
     args:
       - ${{ inputs.args }}
 


### PR DESCRIPTION
Change `runs` `image` property to make GitHub always build a new image. This will allow using the latest version of `plantuml`